### PR TITLE
Expose more kpt setters for ACM configuration and kpt reference clean up

### DIFF
--- a/config-management/Kptfile
+++ b/config-management/Kptfile
@@ -17,3 +17,28 @@ openAPI:
           name: memberships
           listValues:
           - "gke-cluster-1"
+    io.k8s.cli.setters.anthos.configmanagement.git.syncbranch:
+      x-k8s-cli:
+        setter:
+          name: anthos.configmanagement.git.syncbranch
+          value: master
+    io.k8s.cli.setters.anthos.configmanagement.git.secrettype:
+      x-k8s-cli:
+        setter:
+          name: anthos.configmanagement.git.secrettype
+          value: ssh
+    io.k8s.cli.setters.anthos.configmanagement.secretref.name:
+      x-k8s-cli:
+        setter:
+          name: anthos.configmanagement.secretref.name
+          value: git-creds
+    io.k8s.cli.setters.anthos.configmanagement.secretref.namespace:
+      x-k8s-cli:
+        setter:
+          name: anthos.configmanagement.secretref.namespace
+          value: anthos-system
+    io.k8s.cli.setters.anthos.configmanagement.git.policydir:
+      x-k8s-cli:
+        setter:
+          name: anthos.configmanagement.git.policydir
+          value: /

--- a/config-management/feature-spec-1.yaml
+++ b/config-management/feature-spec-1.yaml
@@ -20,10 +20,10 @@ spec:
   # Skipped `clusterName` on purpose: will be filled by ConfigManagementBinding.
   # The Secret used to access the config-management repo.
   secretRef:
-    name: git-creds
-    namespace: anthos-system
+    name: git-creds # {"$kpt-set":"anthos.configmanagement.secretref.name"}
+    namespace: anthos-system # {"$kpt-set":"anthos.configmanagement.secretref.namespace"}
   git:
-    syncRepo: "" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.configmanagement.git.syncrepo"}
-    syncBranch: master
-    secretType: ssh
-    policyDir: "/"
+    syncRepo: "" # {"$kpt-set":"anthos.configmanagement.git.syncrepo"}
+    syncBranch: master # {"$kpt-set":"anthos.configmanagement.git.syncbranch"}
+    secretType: ssh # {"$kpt-set":"anthos.configmanagement.git.secrettype"}
+    policyDir: "/" # {"$kpt-set":"anthos.configmanagement.git.policydir"}

--- a/gke-cluster-1/cluster.yaml
+++ b/gke-cluster-1/cluster.yaml
@@ -14,7 +14,7 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1 # See https://cloud.google.com/config-connector/docs/reference/resource-docs/container/containercluster for all the available options.
 kind: ContainerCluster
 metadata:
-  name: "gke-cluster-1" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster.name"}
+  name: "gke-cluster-1" # {"$kpt-set":"gcloud.container.cluster.name"}
   namespace: anthos-system
   labels:
     mesh_id: "proj-PROJECT_NUMBER" # {"$kpt-set":"mesh-id"}
@@ -23,7 +23,7 @@ metadata:
     # Using dedicated ContainerNodePool, so the default one is not needed
     cnrm.cloud.google.com/remove-default-node-pool: "true"
 spec:
-  location: us-central1-c # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster.location"}
+  location: us-central1-c # {"$kpt-set":"gcloud.container.cluster.location"}
   initialNodeCount: 1
   loggingService: logging.googleapis.com/kubernetes
   monitoringService: monitoring.googleapis.com/kubernetes

--- a/gke-cluster-1/hubmembership.yaml
+++ b/gke-cluster-1/hubmembership.yaml
@@ -14,11 +14,11 @@
 apiVersion: anthos.cloud.google.com/v1alpha1
 kind: HubMembership
 metadata:
-  name: gke-cluster-1 # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster.name"}
+  name: gke-cluster-1 # {"$kpt-set":"gcloud.container.cluster.name"}
   namespace: anthos-system
 spec:
   clusterRef:
     apiGroup: "container.cnrm.cloud.google.com"
     kind: ContainerCluster
     namespace: anthos-system
-    name: gke-cluster-1 # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster.name"}
+    name: gke-cluster-1 # {"$kpt-set":"gcloud.container.cluster.name"}

--- a/gke-cluster-1/nodepool.yaml
+++ b/gke-cluster-1/nodepool.yaml
@@ -14,12 +14,12 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1 # See https://cloud.google.com/config-connector/docs/reference/resource-docs/container/containernodepool for all the available options.
 kind: ContainerNodePool
 metadata:
-  name: "gke-nodepool-1" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.nodepool.name"}
+  name: "gke-nodepool-1" # {"$kpt-set":"gcloud.container.nodepool.name"}
   namespace: anthos-system
   annotations:
     cnrm.cloud.google.com/project-id: "PROJECT_ID" # {"$kpt-set":"gcloud.core.project"}
 spec:
-  location: us-central1-c # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster.location"}
+  location: us-central1-c # {"$kpt-set":"gcloud.container.cluster.location"}
   initialNodeCount: 2
   autoscaling:
     minNodeCount: 2
@@ -36,4 +36,4 @@ spec:
     - https://www.googleapis.com/auth/servicecontrol
     - https://www.googleapis.com/auth/trace.append
   clusterRef:
-    name: "gke-cluster-1" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster.name"}
+    name: "gke-cluster-1" # {"$kpt-set":"gcloud.container.cluster.name"}


### PR DESCRIPTION
1. Create kpt setters:
  - anthos.configmanagement.git.syncbranch
  - anthos.configmanagement.git.secrettype
  - anthos.configmanagement.secretref.name
  - anthos.configmanagement.secretref.namespace
  - anthos.configmanagement.git.policydir

2. Replace definitions/io.k8s.cli.setters with kpt-set